### PR TITLE
plug-ins/libart/export_png.c: 直接メンバを参照しているところをカプセル化

### DIFF
--- a/plug-ins/libart/export_png.c
+++ b/plug-ins/libart/export_png.c
@@ -178,7 +178,7 @@ export_png_ok(GtkButton *button, gpointer userdata)
   }
 
   /* set error handling ... */
-  if (setjmp(png->jmpbuf)) {
+  if (setjmp(png_jmpbuf(png))) {
     fclose(fp);
     png_destroy_write_struct(&png, &info);
     message_error(_("Error occurred while writing PNG"));


### PR DESCRIPTION
libpng 1.4系で jmpbuf へのアクセスが deprecated になったようで、1.6系を使用する Ubuntu 18.04 環境ではビルドに失敗していました。
置き換えたマクロは 1.0系から使えるので、Ubuntu16.04, 18.04 両方でビルドできることを確認しています。